### PR TITLE
Added alternative query protocol

### DIFF
--- a/src/DFPlayerMini_Fast.cpp
+++ b/src/DFPlayerMini_Fast.cpp
@@ -49,8 +49,10 @@
 	 @return True.
  */
  /**************************************************************************/
-bool DFPlayerMini_Fast::begin(Stream &stream, unsigned long threshold)
+bool DFPlayerMini_Fast::begin(Stream &stream, unsigned long threshold, uint8_t protocolMode)
 {
+	this->protocolMode = protocolMode;
+
 	_threshold = threshold;
 	timoutTimer.begin(_threshold);
 
@@ -951,7 +953,7 @@ int16_t DFPlayerMini_Fast::query(uint8_t cmd, uint8_t msb, uint8_t lsb)
 	findChecksum(&sendStack);
 	sendData();
 
-	if (getStatus(cmd))
+	if (getStatus((protocolMode == dfplayer::PROTO_ALT1)?dfplayer::REPLY:cmd))
 		return (recStack.paramMSB << 8) | recStack.paramLSB;
 
 	return -1;

--- a/src/DFPlayerMini_Fast.h
+++ b/src/DFPlayerMini_Fast.h
@@ -114,7 +114,7 @@ namespace dfplayer
 	/** Repeat Play Values */
 	const uint8_t STOP_REPEAT     = 0;
 	const uint8_t START_REPEAT    = 1;
-
+      
 	/** Protocol Mode Values */
 	const uint8_t PROTO_DEFAULT   = 0;
 	const uint8_t PROTO_ALT1      = 1;

--- a/src/DFPlayerMini_Fast.h
+++ b/src/DFPlayerMini_Fast.h
@@ -114,7 +114,7 @@ namespace dfplayer
 	/** Repeat Play Values */
 	const uint8_t STOP_REPEAT     = 0;
 	const uint8_t START_REPEAT    = 1;
-      
+
 	/** Protocol Mode Values */
 	const uint8_t PROTO_DEFAULT   = 0;
 	const uint8_t PROTO_ALT1      = 1;

--- a/src/DFPlayerMini_Fast.h
+++ b/src/DFPlayerMini_Fast.h
@@ -114,6 +114,10 @@ namespace dfplayer
 	/** Repeat Play Values */
 	const uint8_t STOP_REPEAT     = 0;
 	const uint8_t START_REPEAT    = 1;
+
+	/** Protocol Mode Values */
+	const uint8_t PROTO_DEFAULT   = 0;
+	const uint8_t PROTO_ALT1      = 1;
 }
 
 
@@ -129,6 +133,8 @@ class DFPlayerMini_Fast
 public:
 	Stream* _serial;
     
+	uint8_t protocolMode;
+
 	/** Struct to store entire serial datapacket used for MP3 config/control */
 	struct stack {
 		uint8_t start_byte;
@@ -146,7 +152,7 @@ public:
 
 
 
-	bool begin(Stream& stream, unsigned long threshold=500);
+	bool begin(Stream& stream, unsigned long threshold=500, uint8_t protocolMode = dfplayer::PROTO_DEFAULT);
 
 	void playNext();
 	void playPrevious();


### PR DESCRIPTION
This adds a third, optional parameter to begin(), which will be used to decide whether to expect query replies with (for PROTO_DEFAULT) the original command in the CMD byte, or (for PROTO_ALT1), the "Reply" value 0x41.