### PR TITLE
add support to play songs from folders with more than 255 tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ void reset();
 void resume();
 void pause();
 void playFolder(uint8_t folderNum, uint8_t trackNum);
+void playLargeFolder(uint8_t folderNum, uint16_t trackNum);
 void volumeAdjustSet(uint8_t gain);
 void startRepeatPlay();
 void stopRepeatPlay();

--- a/src/DFPlayerMini_Fast.cpp
+++ b/src/DFPlayerMini_Fast.cpp
@@ -462,8 +462,30 @@ void DFPlayerMini_Fast::playFolder(uint8_t folderNum, uint8_t trackNum)
 	sendData();
 }
 
+/**************************************************************************/
+ /*!
+	 @brief  Play a specific track from a specific folder, where the track
+			 names are numbered 4 digit (e.g. 1234-mysong.mp3) and can be 
+			 up to 3000. Only 15 folders ("01" to "15") are supported in this
+			 mode. 
+	 @param    folderNum
+			   The folder number.
+	 @param    trackNum
+			   The track number to play.
+ */
+ /**************************************************************************/
+void DFPlayerMini_Fast::playLargeFolder(uint8_t folderNum, uint16_t trackNum)
+{
+	const uint16_t arg = (((uint16_t)folderNum) << 12) | (trackNum & 0xfff);
 
+	sendStack.commandValue	= dfplayer::SPEC_TRACK_3000;
+	sendStack.feedbackValue = dfplayer::NO_FEEDBACK;
+	sendStack.paramMSB = arg >> 8;
+	sendStack.paramLSB = arg & 0xff;
 
+	findChecksum(sendStack);
+	sendData();
+}
 
 /**************************************************************************/
  /*!

--- a/src/DFPlayerMini_Fast.h
+++ b/src/DFPlayerMini_Fast.h
@@ -169,6 +169,7 @@ public:
 	void resume();
 	void pause();
 	void playFolder(uint8_t folderNum, uint8_t trackNum);
+	void playLargeFolder(uint8_t folderNum, uint16_t trackNum);
 	void volumeAdjustSet(uint8_t gain);
 	void startRepeatPlay();
 	void stopRepeatPlay();


### PR DESCRIPTION
Add a`playLargeFolder()` method to address more than 255 files, using the control command 0x14.

See [chapter 3.6.9](https://github.com/PowerBroker2/DFPlayerMini_Fast/blob/master/extras/FN-M16P%2BEmbedded%2BMP3%2BAudio%2BModule%2BDatasheet.pdf) in the manual for details.